### PR TITLE
Introduce 'Smart Decimation' that preserves shape keys (against development)

### DIFF
--- a/extentions.py
+++ b/extentions.py
@@ -164,9 +164,11 @@ def register():
 
             ("FULL", t('Scene.decimation_mode.full.label'), t('Scene.decimation_mode.full.desc')),
 
+            ("SMART", t('Scene.decimation_mode.smart.label'), t('Scene.decimation_mode.smart.desc'))
+
             ("CUSTOM", t('Scene.decimation_mode.custom.label'), t('Scene.decimation_mode.custom.desc'))
         ],
-        default='HALF'
+        default='SMART'
     )
 
     Scene.selection_mode = EnumProperty(

--- a/extentions.py
+++ b/extentions.py
@@ -164,7 +164,7 @@ def register():
 
             ("FULL", t('Scene.decimation_mode.full.label'), t('Scene.decimation_mode.full.desc')),
 
-            ("SMART", t('Scene.decimation_mode.smart.label'), t('Scene.decimation_mode.smart.desc'))
+            ("SMART", t('Scene.decimation_mode.smart.label'), t('Scene.decimation_mode.smart.desc')),
 
             ("CUSTOM", t('Scene.decimation_mode.custom.label'), t('Scene.decimation_mode.custom.desc'))
         ],

--- a/tools/decimation.py
+++ b/tools/decimation.py
@@ -179,6 +179,7 @@ class AutoDecimateButton(bpy.types.Operator):
         full_decimation = context.scene.decimation_mode == 'FULL'
         half_decimation = context.scene.decimation_mode == 'HALF'
         safe_decimation = context.scene.decimation_mode == 'SAFE'
+        smart_decimation = context.scene.decimation_mode == 'SMART'
         save_fingers = context.scene.decimate_fingers
         max_tris = context.scene.max_tris
         meshes = []
@@ -233,6 +234,17 @@ class AutoDecimateButton(bpy.types.Operator):
                     bpy.ops.object.shape_key_remove(all=True)
                     meshes.append((mesh, tris))
                     tris_count += tris
+                elif smart_decimation:
+                    if len(mesh.data.shape_keys.key_blocks) == 1:
+                        bpy.ops.object.shape_key_remove(all=True)
+                    else:
+                        # Add a duplicate basis key which we un-apply to fix shape keys
+                        mesh.active_shape_key_index = 0
+                        bpy.ops.object.shape_key_add(from_mix=False)
+                        mesh.active_shape_key.name = "CATS Basis"
+                        mesh.active_shape_key_index = 0
+                    meshes.append((mesh, tris))
+                    tris_count += tris
                 elif custom_decimation:
                     found = False
                     for shape in ignore_shapes:
@@ -273,7 +285,7 @@ class AutoDecimateButton(bpy.types.Operator):
             elif custom_decimation:
                 message.append(t('decimate.customTryOptions'))
             if save_fingers:
-                if full_decimation:
+                if full_decimation or smart_decimation:
                     message.append(t('decimate.disableFingersOrIncrease'))
                 else:
                     message[1] = message[1][:-1]
@@ -309,10 +321,22 @@ class AutoDecimateButton(bpy.types.Operator):
             print(decimation)
 
             # Apply decimation mod
-            mod = mesh_obj.modifiers.new("Decimate", 'DECIMATE')
-            mod.ratio = decimation
-            mod.use_collapse_triangulate = True
-            Common.apply_modifier(mod)
+            if not smart_decimation:
+                mod = mesh_obj.modifiers.new("Decimate", 'DECIMATE')
+                mod.ratio = decimation
+                mod.use_collapse_triangulate = True
+                Common.apply_modifier(mod)
+            else:
+                Common.switch('EDIT')
+                bpy.ops.mesh.select_mode(type="VERT")
+                bpy.ops.mesh.select_all(action="SELECT")
+                bpy.ops.mesh.decimate(ratio=decimation,
+                                      use_vertex_group=False,
+                                      vertex_group_factor=1.0,
+                                      invert_vertex_group=False,
+                                      use_symmetry=True,
+                                      symmetry_axis='X')
+                Common.switch('OBJECT')
 
             tris_after = len(mesh_obj.data.polygons)
             print(tris)
@@ -320,6 +344,19 @@ class AutoDecimateButton(bpy.types.Operator):
 
             current_tris_count = current_tris_count - tris + tris_after
             tris_count = tris_count - tris
+            # Repair shape keys if SMART mode is enabled
+            if smart_decimation and len(mesh_obj.data.shape_keys.key_blocks) > 0:
+                for idx in range(1, len(mesh_obj.data.shape_keys.key_blocks) - 2):
+                    print("Key: " + mesh_obj.data.shape_keys.key_blocks[idx].name)
+                    mesh_obj.active_shape_key_index = idx
+                    Common.switch('EDIT')
+                    bpy.ops.mesh.blend_from_shape(shape="CATS Basis", blend=-1.0, add=True)
+                    Common.switch('OBJECT')
+                mesh_obj.shape_key_remove(key=mesh_obj.data.shape_keys.key_blocks["CATS Basis"])
+                mesh_obj.active_shape_key_index = 0
+
+
+
 
             Common.unselect_all()
 

--- a/translations/en_US.py
+++ b/translations/en_US.py
@@ -92,7 +92,8 @@ dictionary = {
     'DecimationPanel.decimationMode': 'Decimation Mode:',
     'DecimationPanel.safeModeDesc': ' Decent results - No shape key loss',
     'DecimationPanel.halfModeDesc': ' Good results - Minimal shape key loss',
-    'DecimationPanel.fullModeDesc': ' Best results - Full shape key loss',
+    'DecimationPanel.fullModeDesc': ' Consistent results - Full shape key loss',
+    'DecimationPanel.smartModeDesc': ' Best results - Preserve shape keys',
     'DecimationPanel.customSeparateMaterials': 'Start by Separating by Materials:',
     'DecimationPanel.SeparateByMaterials.label': 'Separate by Materials',
     'DecimationPanel.customJoinMeshes': 'Stop by Joining Meshes:',
@@ -102,6 +103,14 @@ dictionary = {
     'DecimationPanel.warn.noMeshSelected': 'No mesh selected',
     'DecimationPanel.warn.emptyList': 'Both lists are empty, this equals Full Decimation!',
     'DecimationPanel.warn.correctWhitelist': 'Both whitelists are considered during decimation',
+    'DecimationPanel.preset.excellent.label': 'Excellent',
+    'DecimationPanel.preset.excellent.description': 'The maximum number of tris you can have for an Excellent rating.',
+    'DecimationPanel.preset.good.label': 'Good',
+    'DecimationPanel.preset.good.description': 'The maximum number of tris you can have for a Good rating.',
+    'DecimationPanel.preset.quest.label': 'Quest',
+    'DecimationPanel.preset.quest.description': 'The reccomended number of tris for Quest avatars.\n' \
+                                                'A hard limit will be established in the future that will not be much more than this.',
+
 
     # UI Eye tracking
     'EyeTrackingPanel.label': 'Eye Tracking',
@@ -917,11 +926,16 @@ dictionary = {
                                        'The results are better but you will lose the shape keys in some meshes.\n'
                                        'Eye Tracking and Lip Syncing should still work.',
     'Scene.decimation_mode.full.label': 'Full',
-    'Scene.decimation_mode.full.desc': 'Best results - full shape key loss\n'
+    'Scene.decimation_mode.full.desc': 'Consistent results - full shape key loss\n'
                                        '\n'
                                        'This will decimate your whole model deleting all shape keys in the process.\n'
-                                       'This will give the best results but you will lose the ability to add blinking and Lip Syncing.\n'
+                                       'This will give consistent results but you will lose the ability to add blinking and Lip Syncing.\n'
                                        'Eye Tracking will still work if you disable Eye Blinking.',
+    'Scene.decimation_mode.smart.label': "Smart",
+    'Scene.decimation_mode.smart.desc': 'Best results - repair shape keys after decimation\n'
+                                        '\n'
+                                        "This will decimate your whole model and attempt to undo the warping caused by Blender's decimation.\n"
+                                        "This will give the best results and keep blinking and lip syncing, but may have issues on some models.",
     'Scene.decimation_mode.custom.label': 'Custom',
     'Scene.decimation_mode.custom.desc': 'Custom results - custom shape key loss\n'
                                          '\n'

--- a/ui/decimation.py
+++ b/ui/decimation.py
@@ -13,7 +13,7 @@ from ..translations import t
 class AutoDecimatePresetGood(bpy.types.Operator):
     bl_idname = 'cats_decimation.preset_good'
     bl_label = t('DecimationPanel.preset.good.label')
-    bl_description = t('DecimationPanel.preset.good.label')
+    bl_description = t('DecimationPanel.preset.good.description')
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):
@@ -24,7 +24,7 @@ class AutoDecimatePresetGood(bpy.types.Operator):
 class AutoDecimatePresetExcellent(bpy.types.Operator):
     bl_idname = 'cats_decimation.preset_excellent'
     bl_label = t('DecimationPanel.preset.excellent.label')
-    bl_description = t('DecimationPanel.preset.excellent.label')
+    bl_description = t('DecimationPanel.preset.excellent.description')
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):
@@ -35,7 +35,7 @@ class AutoDecimatePresetExcellent(bpy.types.Operator):
 class AutoDecimatePresetQuest(bpy.types.Operator):
     bl_idname = 'cats_decimation.preset_quest'
     bl_label = t('DecimationPanel.preset.quest.label')
-    bl_description = t('DecimationPanel.preset.quest.label')
+    bl_description = t('DecimationPanel.preset.quest.description')
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     def execute(self, context):

--- a/ui/decimation.py
+++ b/ui/decimation.py
@@ -9,6 +9,38 @@ from ..tools import armature_manual as Armature_manual
 from ..tools.register import register_wrap
 from ..translations import t
 
+@register_wrap
+class AutoDecimatePresetGood(bpy.types.Operator):
+    bl_idname = 'cats_decimation.preset_good'
+    bl_label = t('DecimationPanel.preset.good.label')
+    bl_description = t('DecimationPanel.preset.good.label')
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    def execute(self, context):
+        bpy.context.scene.max_tris = 70000
+        return {'FINISHED'}
+
+@register_wrap
+class AutoDecimatePresetExcellent(bpy.types.Operator):
+    bl_idname = 'cats_decimation.preset_excellent'
+    bl_label = t('DecimationPanel.preset.excellent.label')
+    bl_description = t('DecimationPanel.preset.excellent.label')
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    def execute(self, context):
+        bpy.context.scene.max_tris = 32000
+        return {'FINISHED'}
+
+@register_wrap
+class AutoDecimatePresetQuest(bpy.types.Operator):
+    bl_idname = 'cats_decimation.preset_quest'
+    bl_label = t('DecimationPanel.preset.quest.label')
+    bl_description = t('DecimationPanel.preset.quest.label')
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    def execute(self, context):
+        bpy.context.scene.max_tris = 5000
+        return {'FINISHED'}
 
 @register_wrap
 class DecimationPanel(ToolPanel, bpy.types.Panel):
@@ -39,6 +71,8 @@ class DecimationPanel(ToolPanel, bpy.types.Panel):
             row.label(text=t('DecimationPanel.halfModeDesc'))
         elif context.scene.decimation_mode == 'FULL':
             row.label(text=t('DecimationPanel.fullModeDesc'))
+        elif context.scene.decimation_mode == 'SMART':
+            row.label(text=t('DecimationPanel.smartModeDesc'))
 
         elif context.scene.decimation_mode == 'CUSTOM':
             col.separator()
@@ -132,6 +166,10 @@ class DecimationPanel(ToolPanel, bpy.types.Panel):
         row.prop(context.scene, 'decimate_fingers')
         row = col.row(align=True)
         row.prop(context.scene, 'decimation_remove_doubles')
+        row = col.row(align=True)
+        row.operator(AutoDecimatePresetGood.bl_idname)
+        row.operator(AutoDecimatePresetExcellent.bl_idname)
+        row.operator(AutoDecimatePresetQuest.bl_idname)
         row = col.row(align=True)
         row.prop(context.scene, 'max_tris')
         col.separator()


### PR DESCRIPTION
Supercedes #216, since Github doesn't allow changing the source branch.

I think I got everything right, but I'm getting a complaint about dictionaries when I try to load it in blender 2.83, could you double-check that it's not just a 'me' issue?

(I didn't attempt to provide japanese translations)