### PR TITLE
Check for lowercase head bones when baking

### DIFF
--- a/tools/bake.py
+++ b/tools/bake.py
@@ -472,10 +472,12 @@ class BakeButton(bpy.types.Operator):
             bpy.ops.uv.average_islands_scale()  # Use blender average so we can make our own tweaks.
             Common.switch('OBJECT')
 
+            head_selection = Common.get_bones(names=['Head', 'head'], armature_name=arm_copy.name, check_list=True)
+
             # Select all islands belonging to 'Head' and children and enlarge them
-            if prioritize_face and "Head" in arm_copy.data.bones:
-                selected_group_names = ["Head"]
-                selected_group_names.extend([bone.name for bone in arm_copy.data.bones["Head"].children_recursive])
+            if prioritize_face and len(head_selection) > 0:
+                selected_group_names = [head_selection[0][0]]
+                selected_group_names.extend([bone.name for bone in arm_copy.data.bones[head_selection[0][0]].children_recursive])
                 print("Prioritizing vertex groups: " + (", ".join(selected_group_names)))
 
                 for obj in collection.all_objects:

--- a/tools/common.py
+++ b/tools/common.py
@@ -531,7 +531,7 @@ def get_bones_merge(self, context):
 
 
 # names - The first object will be the first one in the list. So the first one has to be the one that exists in the most models
-def get_bones(names=None, armature_name=None):
+def get_bones(names=None, armature_name=None, check_list=False):
     if not names:
         names = []
     if not armature_name:
@@ -564,8 +564,9 @@ def get_bones(names=None, armature_name=None):
         if name in armature.data.bones and choices[0][0] != name:
             choices2.append((name, name, name))
 
-    for choice in choices:
-        choices2.append(choice)
+    if not check_list:
+        for choice in choices:
+            choices2.append(choice)
 
     bpy.types.Object.Enum = choices2
 

--- a/tools/decimation.py
+++ b/tools/decimation.py
@@ -261,14 +261,15 @@ class AutoDecimateButton(bpy.types.Operator):
                 # Weight by relative shape key movement. This is kind of slow, but not too bad. It's O(n*m) for n verts and m shape keys,
                 # but shape keys contain every vert (not just the ones they impact)
                 # For shape key in shape keys:
-                for key_block in mesh.data.shape_keys.key_blocks[1:]:
-                    basis = mesh.data.shape_keys.key_blocks[0]
-                    s_weights[key_block.name] = dict()
+                if mesh.data.shape_keys is not None:
+                    for key_block in mesh.data.shape_keys.key_blocks[1:]:
+                        basis = mesh.data.shape_keys.key_blocks[0]
+                        s_weights[key_block.name] = dict()
 
-                    for idx, vert in enumerate(key_block.data):
-                        s_weights[key_block.name][idx] = math.sqrt(math.pow(basis.data[idx].co[0] - vert.co[0], 2.0) +
-                                                                        math.pow(basis.data[idx].co[1] - vert.co[1], 2.0) +
-                                                                        math.pow(basis.data[idx].co[2] - vert.co[2], 2.0))
+                        for idx, vert in enumerate(key_block.data):
+                            s_weights[key_block.name][idx] = math.sqrt(math.pow(basis.data[idx].co[0] - vert.co[0], 2.0) +
+                                                                            math.pow(basis.data[idx].co[1] - vert.co[1], 2.0) +
+                                                                            math.pow(basis.data[idx].co[2] - vert.co[2], 2.0))
 
                 # normalize min/max vert movement
                 s_normalizedweights = dict()

--- a/ui/bake.py
+++ b/ui/bake.py
@@ -60,7 +60,8 @@ class BakePanel(ToolPanel, bpy.types.Panel):
                 row = col.row(align=True)
                 row.separator()
                 row.prop(context.scene, 'bake_face_scale', expand=True)
-                if armature is None or "Head" not in armature.data.bones:
+
+                if armature is None or len(Common.get_bones(names=['Head', 'head'], armature_name=armature.name, check_list=True)) == 0:
                     row = col.row(align=True)
                     row.separator()
                     row.label(text=t('BakePanel.noheadfound'), icon="INFO")


### PR DESCRIPTION
Currently the `bake.py` tool and it's UI counterpart only checks the armature for `Head` bones. If you have a `head` (note that it's lowercase) bone though, it fails. So to fix this I modified the pre-existing `get_bones` function from `common.py` and used it instead, and the output confirms that it's being prioritized correctly:

```Prioritizing vertex groups: head, jaw, eye.L, eye.R, lower left eyelid.L, lower left eyelid.R, mouth raise.L, mouth raise.R, ear.L, ear.R, bangs.L, bangs.R, back hair, lower right eyelid.L, lower right eyelid.R, upper left eyelid.L, upper left eyelid.R, upper right eyelid.L, upper right eyelid.R```

The only thing i'm not sure about that it's necessary to modify `get_bones` to accomplish this, but it doesn't seem to actually filter bones by names, unless i'm missing something?